### PR TITLE
Resolve test method parameters from ApplicationContext

### DIFF
--- a/src/main/java/org/springframework/test/context/junit5/SpringExtension.java
+++ b/src/main/java/org/springframework/test/context/junit5/SpringExtension.java
@@ -94,7 +94,7 @@ public class SpringExtension implements BeforeAllExtensionPoint, AfterAllExtensi
 	 * Get the {@link TestContextManager} associated with the supplied test class.
 	 * @param testClass the test class to be managed; never {@code null}
 	 */
-	private TestContextManager getTestContextManager(Class<?> testClass) {
+	protected TestContextManager getTestContextManager(Class<?> testClass) {
 		Assert.notNull(testClass, "testClass must not be null");
 		return this.tcmCache.computeIfAbsent(testClass, TestContextManager::new);
 	}

--- a/src/main/java/org/springframework/test/context/junit5/SpringParameterExtension.java
+++ b/src/main/java/org/springframework/test/context/junit5/SpringParameterExtension.java
@@ -1,0 +1,65 @@
+package org.springframework.test.context.junit5;
+
+import org.junit.gen5.api.extension.ExtensionContext;
+import org.junit.gen5.api.extension.MethodInvocationContext;
+import org.junit.gen5.api.extension.MethodParameterResolver;
+import org.junit.gen5.api.extension.ParameterResolutionException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestContextManager;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+/**
+ * @author Tadaya Tsuyukubo
+ */
+public class SpringParameterExtension extends SpringExtension implements MethodParameterResolver {
+
+	@Override
+	public boolean supports(Parameter parameter, MethodInvocationContext methodInvocationContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+		return true;  // TODO: should check
+	}
+
+	@Override
+	public Object resolve(Parameter parameter, MethodInvocationContext methodInvocationContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+
+		ApplicationContext applicationContext = getApplicationContext(extensionContext.getTestClass());
+
+		// special case for application context
+		if (ApplicationContext.class.isAssignableFrom(parameter.getType())) {
+			return applicationContext;
+		}
+
+		// TODO: need to resolve beans more sophisticated way. for example, generics support
+
+		Object bean;
+
+		Qualifier qualifier = parameter.getAnnotation(Qualifier.class);
+		if (qualifier != null) {
+			bean = applicationContext.getBean(qualifier.value());
+			if (bean != null) {
+				return bean;
+			}
+		}
+
+		bean = applicationContext.getBean(parameter.getType());
+		if (bean != null) {
+			return bean;
+		}
+		return applicationContext.getBean(parameter.getName());
+	}
+
+	private ApplicationContext getApplicationContext(Class<?> testClass) {
+		TestContextManager manager = getTestContextManager(testClass);
+
+		// hack to get TestContext
+		Method method = ReflectionUtils.findMethod(TestContextManager.class, "getTestContext");
+		ReflectionUtils.makeAccessible(method);
+		TestContext testContext = (TestContext) ReflectionUtils.invokeMethod(method, manager);
+
+		return testContext.getApplicationContext();
+	}
+}

--- a/src/test/java/org/springframework/test/context/junit5/SpringParameterExtensionTests.java
+++ b/src/test/java/org/springframework/test/context/junit5/SpringParameterExtensionTests.java
@@ -1,0 +1,44 @@
+package org.springframework.test.context.junit5;
+
+import org.junit.gen5.api.Disabled;
+import org.junit.gen5.api.Test;
+import org.junit.gen5.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+
+import static org.junit.gen5.api.Assertions.assertEquals;
+import static org.junit.gen5.api.Assertions.assertNotNull;
+import static org.junit.gen5.api.Assertions.assertSame;
+
+/**
+ * @author Tadaya Tsuyukubo
+ */
+@ExtendWith(SpringParameterExtension.class)
+@ContextConfiguration(classes = TestConfig.class)
+public class SpringParameterExtensionTests {
+
+	@Autowired
+	ApplicationContext applicationContext;
+
+	@Test
+	void applicationContextInjectedToMethodParameter(ApplicationContext paramApplicationContext) {
+		assertSame(this.applicationContext, paramApplicationContext, "same ApplicationContext should be resolved in parameter");
+	}
+
+	@Test
+	void springBeansInjectedToParameterWithQualifier(@Qualifier("dilbert") Person dilbert) {
+		assertNotNull(dilbert, "Person should be resolved in method parameter");
+		assertEquals("Dilbert", dilbert.getName(), "Person's name");
+	}
+
+	@Test
+	@Disabled  // generics is not supported yet
+	void springBeansInjectedToParameterWithGenerics(List<Person> people) {
+		assertEquals(2, people.size(), "Number of Person objects in context");
+	}
+
+}


### PR DESCRIPTION
`SpringParameterExtension` class that implements `MethodParameterResolver`
to enhance `SpringExtension` for test method parameter resolution using
`ApplicationContext`.
