### PR TITLE
Introduce ExternalApplicationContext annotation

### DIFF
--- a/src/main/java/org/springframework/test/context/junit5/external/ApplicationContextProvider.java
+++ b/src/main/java/org/springframework/test/context/junit5/external/ApplicationContextProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit5.external;
+
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Strategy interface to provide {@link ApplicationContext} for dependency injection into test instance.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 5.0
+ *
+ * @see ExternalApplicationContext
+ */
+public interface ApplicationContextProvider {
+
+	default void initialize() {
+	}
+
+	ApplicationContext getApplicationContext();
+
+	// TODO: more callbacks such as reInitialize() for dirtied context, destroy(), etc.
+
+}

--- a/src/main/java/org/springframework/test/context/junit5/external/ExternalApplicationContext.java
+++ b/src/main/java/org/springframework/test/context/junit5/external/ExternalApplicationContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit5.external;
+
+import org.junit.gen5.api.extension.ExtendWith;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Resolve dependencies on annotated test class from {@link ApplicationContext} provided by {@link ApplicationContextProvider}.
+ *
+ * This annotation is a composed annotation.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 5.0
+ */
+@ExtendWith(SpringInjectionExtension.class)
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface ExternalApplicationContext {
+
+	@AliasFor("provider")
+	Class<? extends ApplicationContextProvider> value() default ApplicationContextProvider.class;
+
+	@AliasFor("value")
+	Class<? extends ApplicationContextProvider> provider() default ApplicationContextProvider.class;
+
+}

--- a/src/main/java/org/springframework/test/context/junit5/external/SpringInjectionExtension.java
+++ b/src/main/java/org/springframework/test/context/junit5/external/SpringInjectionExtension.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit5.external;
+
+import org.junit.gen5.api.extension.InstancePostProcessor;
+import org.junit.gen5.api.extension.TestExtensionContext;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Inject dependencies to the test instance from {@link ApplicationContext} provided by {@link ApplicationContextProvider}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 5.0
+ */
+public class SpringInjectionExtension implements InstancePostProcessor {
+
+	// TODO: static or not, based on how InstantPostProcessor gets created
+	private final ConcurrentHashMap<Class<? extends ApplicationContextProvider>, ApplicationContextProvider> providerCache =
+			new ConcurrentHashMap<>(64);
+
+	@Override
+	public void postProcessTestInstance(TestExtensionContext context) throws Exception {
+
+		ExternalApplicationContext externalApplicationContext = AnnotationUtils
+				.findAnnotation(context.getTestClass(), ExternalApplicationContext.class);
+		Class<? extends ApplicationContextProvider> providerClass = externalApplicationContext.provider();
+
+		// find or create ApplicationContextProvider
+		providerCache.computeIfAbsent(providerClass, aClass -> {
+			ApplicationContextProvider provider = BeanUtils.instantiateClass(providerClass);
+			provider.initialize();
+			return provider;
+		});
+		ApplicationContextProvider provider = providerCache.get(providerClass);
+
+		// retrieve ApplicationContext
+		ApplicationContext applicationContext = provider.getApplicationContext();
+		AutowireCapableBeanFactory beanFactory = applicationContext.getAutowireCapableBeanFactory();
+
+		// inject to test instance
+		Object testInstance = context.getTestInstance();
+		beanFactory.autowireBeanProperties(testInstance, AutowireCapableBeanFactory.AUTOWIRE_NO, false);
+		beanFactory.initializeBean(testInstance, context.getName());
+
+	}
+
+}

--- a/src/test/java/org/springframework/test/context/junit5/external/ExternalApplicationContextTests.java
+++ b/src/test/java/org/springframework/test/context/junit5/external/ExternalApplicationContextTests.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright 2015-2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.test.context.junit5.external;
+
+import org.junit.gen5.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.gen5.api.Assertions.assertEquals;
+import static org.junit.gen5.api.Assertions.assertNotNull;
+import static org.junit.gen5.api.Assertions.assertSame;
+import static org.springframework.test.context.junit5.external.ExternalApplicationContextTests.MyApplicationContextProvider;
+
+/**
+ * @author Tadaya Tsuyukubo
+ * @since 5.0
+ */
+@ExternalApplicationContext(provider = MyApplicationContextProvider.class)
+public class ExternalApplicationContextTests {
+
+	@Autowired
+	String message;
+
+	@Autowired
+	Foo foo;
+
+	@Autowired
+	ApplicationContext externalApplicationContext;
+
+	@Test
+	void variablesInjected() {
+		assertEquals("Hello from outside", message);
+
+		assertNotNull(foo);
+		assertEquals("FOO", foo.name);
+	}
+
+	@Test
+	void applicationContextInjected() {
+		assertNotNull(externalApplicationContext, "External ApplicationContext should have been injected");
+		assertSame(MyApplicationContextProvider.applicationContext, externalApplicationContext);
+		assertEquals(foo, externalApplicationContext.getBean(Foo.class));
+	}
+
+	static class MyApplicationContextProvider implements ApplicationContextProvider {
+
+		static ApplicationContext applicationContext;
+
+		@Override
+		public void initialize() {
+			applicationContext = new AnnotationConfigApplicationContext(MyConfiguration.class);
+		}
+
+		@Override
+		public ApplicationContext getApplicationContext() {
+			return applicationContext;
+		}
+	}
+
+	@Configuration
+	static class MyConfiguration {
+		@Bean
+		String message() {
+			return "Hello from outside";
+		}
+
+		@Bean
+		Foo foo() {
+			return new Foo("FOO");
+		}
+	}
+
+	static class Foo {
+		String name;
+
+		public Foo(String name) {
+			this.name = name;
+		}
+	}
+
+}


### PR DESCRIPTION
This is another POC but concept is not limited to junit5.

In Spring TCF, application context is managed by framework.
`@ExternalApplicationContext` annotation provides means to use external `ApplicationContext` for dependency injection into the test class instance.
